### PR TITLE
Разрешает использовать терраформ больше либо равен версии 1.0.4

### DIFF
--- a/db_instance/versions.tf
+++ b/db_instance/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.0.4"
+  required_version = ">= 1.0.4"
   required_providers {
     mcs = {
       source = "MailRuCloudSolutions/mcs"


### PR DESCRIPTION
Т.к данный модуль был протестирован только с терраформом версии 1.0.4
то версии ниже не рекомендуется использовать.